### PR TITLE
Add body checks to identify POD export job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Mac
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Required env variables:
 - `ALMA_CHALLENGE_SECRET=itsasecret`: this value will work with the test fixtures, must
   match Alma sandbox/prod configured challenge secrets in Dev1, stage, and prod
   environments.
+- `ALMA_POD_EXPORT_JOB_NAME`: the exact name of the POD export job in Alma, must match
+  Alma sandbox/prod configured job name in Dev1, stage, and prod environments.
 - `WORKSPACE=dev`: env for local development.
 - `SENTRY_DSN`: only needed in production.
 
@@ -24,7 +26,7 @@ Required env variables:
 - Run the container:
   ```bash
   docker run -p 9000:8080 -e WORKSPACE=dev -e ALMA_CHALLENGE_SECRET=itsasecret \
-  alma-webhook-lambdas:latest
+  -e ALMA_POD_EXPORT_JOB_NAME="PPOD Export" alma-webhook-lambdas:latest
   ```
 - GET request example
   - Post data to the container:
@@ -48,7 +50,7 @@ Required env variables:
     ```bash
     curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -H \
     "Content-Type: application/json" -d \
-    '{"headers": {"x-exl-signature": "bbQKggzWRSuwopIwszy757lusNZWOPllfv5Rt6Qj8uE="}, "requestContext": {"http": {"method": "POST"}}, "body": {"action": "JOB_END"}}'
+    '{"headers": {"x-exl-signature": "bsCrJo2dPgdNz9uuW/NTXcQfSxdM0M/6Sy7b4eoz60Y="}, "requestContext": {"http": {"method": "POST"}},  "body": "{\"action\": \"JOB_END\", \"job_instance\": {\"name\": \"PPOD Export\", \"status\": {\"value\": \"COMPLETED_SUCCESS\"}, \"counter\": [{\"type\": {\"value\": \"label.updated.records\"}, \"value\": \"1\"}]}}"}'
     ```
   - Observe output:
     ```json
@@ -56,7 +58,7 @@ Required env variables:
       "headers": {"Content-Type": "text/plain"},
       "isBase64Encoded": false,
       "statusCode": 200,
-      "body": "Webhook POST request received and validated, no action taken."
+      "body": "Webhook POST request received and validated, initiating POD upload."
     }
     ```
 

--- a/lambdas/webhook.py
+++ b/lambdas/webhook.py
@@ -73,6 +73,23 @@ def handle_post_request(event: dict) -> dict[str, object]:
             "body": "Unable to validate signature. Has the webhook challenge secret "
             "changed?",
         }
+
+    message_body = json.loads(event["body"])
+    if message_body["action"] != "JOB_END":
+        logger.warning(
+            "Received a non-JOB_END webhook POST request, returning a 400 error "
+            "response."
+        )
+        return {
+            "statusCode": 400,
+            "body": "Webhook POST request was not a JOB_END action. Has the webhook "
+            "configuration changed?",
+        }
+
+    if message_body["job_instance"]["name"] == os.environ["ALMA_POD_EXPORT_JOB_NAME"]:
+        logger.info("POD export job webhook received.")
+        return handle_pod_export_webhook(message_body)
+
     logger.info(
         "POST request received and validated, no action triggered. Returning 200 "
         "success response."
@@ -85,7 +102,7 @@ def handle_post_request(event: dict) -> dict[str, object]:
 
 def valid_signature(event: dict) -> bool:
     secret = os.environ["ALMA_CHALLENGE_SECRET"]
-    message = json.dumps(event["body"])
+    message = event["body"]
     try:
         request_signature = event["headers"]["x-exl-signature"]
     except KeyError:
@@ -93,3 +110,52 @@ def valid_signature(event: dict) -> bool:
     message_hash = hmac.digest(secret.encode(), msg=message.encode(), digest="sha256")
     expected_signature = base64.b64encode(message_hash).decode()
     return request_signature == expected_signature
+
+
+def handle_pod_export_webhook(message_body: dict) -> dict[str, object]:
+    if message_body["job_instance"]["status"]["value"] != "COMPLETED_SUCCESS":
+        logger.warning(
+            "POD export job did not complete successfully, may need investigation. "
+            "Returning 200 success response."
+        )
+        return {
+            "statusCode": 200,
+            "body": "Webhook POST request received and validated, POD export job "
+            "failed so no action was taken.",
+        }
+
+    if count_exported_records(message_body["job_instance"]["counter"]) == 0:
+        logger.info(
+            "POD job did not export any records, no action needed. Returning 200 "
+            "success response."
+        )
+        return {
+            "statusCode": 200,
+            "body": "Webhook POST request received and validated, POD export job "
+            "exported zero records so no action was taken.",
+        }
+
+    logger.info(
+        "POD export from Alma completed successfully, initiating POD upload step "
+        "function."
+    )
+    return {
+        "statusCode": 200,
+        "body": "Webhook POST request received and validated, initiating POD upload.",
+    }
+
+
+def count_exported_records(counter: list[dict]) -> int:
+    exported_record_types = [
+        "label.new.records",
+        "label.updated.records",
+        "label.deleted.records",
+    ]
+    count = sum(
+        [
+            int(c["value"])
+            for c in counter
+            if c["type"]["value"] in exported_record_types
+        ]
+    )
+    return count

--- a/lambdas/webhook.py
+++ b/lambdas/webhook.py
@@ -77,13 +77,13 @@ def handle_post_request(event: dict) -> dict[str, object]:
     message_body = json.loads(event["body"])
     if message_body["action"] != "JOB_END":
         logger.warning(
-            "Received a non-JOB_END webhook POST request, returning a 400 error "
-            "response."
+            "Received a non-JOB_END webhook POST request, may require investigation. "
+            "Returning 200 success response."
         )
         return {
-            "statusCode": 400,
-            "body": "Webhook POST request was not a JOB_END action. Has the webhook "
-            "configuration changed?",
+            "statusCode": 200,
+            "body": "Webhook POST request received and validated, not a JOB_END "
+            "webhook so no action was taken.",
         }
 
     if message_body["job_instance"]["name"] == os.environ["ALMA_POD_EXPORT_JOB_NAME"]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 def test_env():
     os.environ = {
         "ALMA_CHALLENGE_SECRET": "itsasecret",
+        "ALMA_POD_EXPORT_JOB_NAME": "PPOD Export",
         "WORKSPACE": "test",
     }
     return
@@ -26,7 +27,7 @@ def post_request_invalid_signature():
     request_data = {
         "headers": {"x-exl-signature": "thisiswrong"},
         "requestContext": {"http": {"method": "POST"}},
-        "body": {"action": "JOB_END"},
+        "body": "The POST request body",
     }
     return request_data
 
@@ -34,8 +35,8 @@ def post_request_invalid_signature():
 @pytest.fixture()
 def post_request_valid_signature():
     request_data = {
-        "headers": {"x-exl-signature": "bbQKggzWRSuwopIwszy757lusNZWOPllfv5Rt6Qj8uE="},
+        "headers": {"x-exl-signature": "e9SHoXK4MZrSGqhglMK4w+/u1pjYn0bfTEYtcFqj7CE="},
         "requestContext": {"http": {"method": "POST"}},
-        "body": {"action": "JOB_END"},
+        "body": "The POST request body",
     }
     return request_data

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -101,15 +101,16 @@ def test_webhook_handles_post_request_not_job_end(caplog):
     expected_output = {
         "headers": {"Content-Type": "text/plain"},
         "isBase64Encoded": False,
-        "statusCode": 400,
-        "body": "Webhook POST request was not a JOB_END action. Has the webhook "
-        "configuration changed?",
+        "statusCode": 200,
+        "body": "Webhook POST request received and validated, not a JOB_END "
+        "webhook so no action was taken.",
     }
     assert lambda_handler(request_data, {}) == expected_output
     assert (
         "lambdas.webhook",
         30,
-        "Received a non-JOB_END webhook POST request, returning a 400 error response.",
+        "Received a non-JOB_END webhook POST request, may require investigation. "
+        "Returning 200 success response.",
     ) in caplog.record_tuples
 
 


### PR DESCRIPTION
#### What does this PR do?
Adds checks to the webhook POST request body to determine whether it came from a successful POD export job, then log and return the appropriate response in all cases.

#### How can a reviewer manually see the effects of these changes?
One way is to follow the instructions in the README to run locally and see what the response will look like for a successful POD export job. Alternatively, this has been pushed to Dev1 so you can test it there by running a POD export job from the Alma sandbox and looking at the logs.

#### Includes new or updated dependencies?
NO

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/ENSY-73

#### Developer
- [x] All new ENV is documented in README
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
- [ ] Why these changes are being introduced: