### PR TITLE
Add stage commands to workflow and makefile

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -1,0 +1,20 @@
+### This is the Terraform-generated stage-build.yml workflow for the alma-webhook-lambdas-stage repository ###
+name: Stage Build and Deploy Lambda Container
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  deploy:
+    name: Stage Deploy Lambda Container
+    uses: mitlibraries/.github/.github/workflows/lambda-shared-deploy-stage.yml@container-flows
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE: "alma-webhook-lambdas-gha-stage"
+      ECR: "alma-webhook-lambdas-stage"
+      FUNCTION: "alma-webhook-lambdas-stage"

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -2,7 +2,7 @@
 name: Stage Build and Deploy Lambda Container
 on:
   workflow_dispatch:
-  pull_request:
+  push:
     branches:
       - main
     paths-ignore:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ ECR_NAME_DEV:=alma-webhook-lambdas-dev
 ECR_URL_DEV:=222053980223.dkr.ecr.us-east-1.amazonaws.com/alma-webhook-lambdas-dev
 FUNCTION_DEV:=alma-webhook-lambdas-dev
 ### End of Terraform-generated header ###
+### This is the Terraform-generated header for alma-webhook-lambdas-stage
+ECR_NAME_STAGE:=alma-webhook-lambdas-stage
+ECR_URL_STAGE:=840055183494.dkr.ecr.us-east-1.amazonaws.com/alma-webhook-lambdas-stage
+FUNCTION_STAGE:=alma-webhook-lambdas-stage
+### End of Terraform-generated header ###
 
 help: ## Print this message
 	@awk 'BEGIN { FS = ":.*##"; print "Usage:  make <target>\n\nTargets:" } \
@@ -63,3 +68,19 @@ update-lambda-dev: ## Updates the lambda with whatever is the most recent image 
 		--function-name $(FUNCTION_DEV) \
 		--image-uri $(ECR_URL_DEV):latest
 		
+### developer Deploy Commands ###
+dist-stage: ## Build docker container (intended for developer-based manual build)
+	docker build --platform linux/amd64 \
+	    -t $(ECR_URL_STAGE):latest \
+		-t $(ECR_URL_STAGE):`git describe --always` \
+		-t $(ECR_NAME_STAGE):latest .
+
+publish-stage: dist-stage ## Build, tag and push (intended for developer-based manual publish)
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_STAGE)
+	docker push $(ECR_URL_STAGE):latest
+	docker push $(ECR_URL_STAGE):`git describe --always`
+
+update-lambda-stage: ## Updates the lambda with whatever is the most recent image in the ecr (intended for developer-based manual update)
+	aws lambda update-function-code \
+		--function-name $(FUNCTION_STAGE) \
+		--image-uri $(ECR_URL_STAGE):latest

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ECR_NAME_DEV:=alma-webhook-lambdas-dev
 ECR_URL_DEV:=222053980223.dkr.ecr.us-east-1.amazonaws.com/alma-webhook-lambdas-dev
 FUNCTION_DEV:=alma-webhook-lambdas-dev
 ### End of Terraform-generated header ###
-### This is the Terraform-generated header for alma-webhook-lambdas-stage
+### This is the Terraform-generated Makefile header for alma-webhook-lambdas-stage
 ECR_NAME_STAGE:=alma-webhook-lambdas-stage
 ECR_URL_STAGE:=840055183494.dkr.ecr.us-east-1.amazonaws.com/alma-webhook-lambdas-stage
 FUNCTION_STAGE:=alma-webhook-lambdas-stage
@@ -68,7 +68,7 @@ update-lambda-dev: ## Updates the lambda with whatever is the most recent image 
 		--function-name $(FUNCTION_DEV) \
 		--image-uri $(ECR_URL_DEV):latest
 		
-### developer Deploy Commands ###
+## Terraform-generated Makefile developer Deploy Commands ###
 dist-stage: ## Build docker container (intended for developer-based manual build)
 	docker build --platform linux/amd64 \
 	    -t $(ECR_URL_STAGE):latest \


### PR DESCRIPTION
# Subject
Sets up the stage workflow and updates the makefile with stage specific commands

# Why these changes are being introduced:
Stage has been deployed, so we need stage workflow and makefile commands

# How this addresses that need:
This is a copy/paste from the infrastructure outputs for stage.

# Side effects of this change:
None

# Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/ENSY-81
